### PR TITLE
Allow `templates list` cmd to filter via 2 flags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,30 @@
-# Contributing
+## Contributing
+Thank you for your interest in contributing to Codewind. We welcome your additions to this project.
 
-To contribute to the Codewind project, see the [Codewind GitHub Workflows](https://wiki.eclipse.org/Codewind_GitHub_Workflows) wiki.
+#### Signing the Eclipse Contributor Agreement (ECA)
+Before you can contribute to any Eclipse project, you need to sign the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php).
+1. To verify that you signed the ECA, sign in to [https://accounts.eclipse.org/ your Eclipse account].
+2. View your **Status** and make sure that a check mark appears with the **Eclipse Contributor Agreement**.
+3. If the check mark does not appear, click the **Eclipse Contributor Agreement** in the **Status** box to go to the agreement that you need to sign.
+4. Fill the form and click the **Accept** button.
 
-If you have questions, [visit us on Slack](https://slack-invite-ibm-cloud-tech.mybluemix.net/).
+#### Associating your Eclipse profile with your GitHub ID
+1. From your Eclipse account, select **Edit Profile**.
+2. On the **Personal Information** tab, go to the **Social Media Links** section and add your GitHub user name to the **GitHub Username** field.
+3. Answer the **Have you changed employers** question.
+4. Enter your Eclipse password in the **Current password** field and then click **Save**.
+
+For more information about Codewind workflows, see the [Codewind GitHub Workflows wiki](https://wiki.eclipse.org/Codewind_GitHub_Workflows).
+
+#### Checking if your issue is already addressed
+- Search the [list of issues](https://github.com/eclipse/codewind/issues) to see if your issue has already been raised.
+- See the [Codewind documentation](https://www.eclipse.org/codewind/docindex.html) to see if existing documentation addresses your question or concern.
+
+#### Creating a new issue
+If you do not see your issue, please [select the issue type in the Codewind repository to open a new issue](https://github.com/eclipse/codewind/issues/new/choose).
+- **Bugs:** Complete the bug template to report problems found in Codewind.
+- **Enhancements:** Complete the enhancement template to suggest improvements to Codewind.
+- **Questions:** Complete the question template to ask a question about Codewind.
+
+## Contact us
+If you have questions, please visit us on Mattermost](https://mattermost.eclipse.org/eclipse/channels/eclipse-codewind).

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,10 +2,10 @@
 
 pipeline {
 
-	agent {
-		kubernetes {
-      		label 'go-pod'
-			yaml """
+    agent {
+        kubernetes {
+              label 'go-pod'
+            yaml """
 apiVersion: v1
 kind: Pod
 spec:
@@ -23,62 +23,63 @@ spec:
         memory: "2Gi"
         cpu: "1"
 """
-    	}
-	}
+        }
+    }
 
     options {
-		timestamps()
+        timestamps()
         skipStagesAfterUnstable()
     }
 
-	environment {
-		CODE_DIRECTORY_FOR_GO = 'src/github.com/eclipse/codewind-installer'
-		DEFAULT_WORKSPACE_DIR_FILE = 'temp_default_dir'
-	}
+    environment {
+        CODE_DIRECTORY_FOR_GO = 'src/github.com/eclipse/codewind-installer'
+        DEFAULT_WORKSPACE_DIR_FILE = 'temp_default_dir'
+    }
 
-	stages {
+    stages {
 
-		stage ('Build') {
-			steps {
-				container('go') {
-					sh 'echo "starting preInstall.....: GOPATH=$GOPATH"'
-					sh '''
-						# add the base directory to the gopath
-						DEFAULT_CODE_DIRECTORY=$PWD
-						cd ../..
-						export GOPATH=$GOPATH:$(pwd)
+        stage ('Build') {
+            steps {
+                container('go') {
+                    sh '''
+                        echo "starting preInstall.....: GOPATH=$GOPATH"
 
-						# create a new directory to store the code for go compile
-						if [ -d $CODE_DIRECTORY_FOR_GO ]; then
-							rm -rf $CODE_DIRECTORY_FOR_GO
-						fi
-						mkdir -p $CODE_DIRECTORY_FOR_GO
-						cd $CODE_DIRECTORY_FOR_GO
+                        # add the base directory to the gopath
+                        DEFAULT_CODE_DIRECTORY=$PWD
+                        cd ../..
+                        export GOPATH=$GOPATH:$(pwd)
 
-						# copy the code into the new directory for go compile
-						cp -r $DEFAULT_CODE_DIRECTORY/* .
-						echo $DEFAULT_CODE_DIRECTORY >> $DEFAULT_WORKSPACE_DIR_FILE
+                        # create a new directory to store the code for go compile
+                        if [ -d $CODE_DIRECTORY_FOR_GO ]; then
+                            rm -rf $CODE_DIRECTORY_FOR_GO
+                        fi
+                        mkdir -p $CODE_DIRECTORY_FOR_GO
+                        cd $CODE_DIRECTORY_FOR_GO
 
-						# get dep and run it
-						wget -O - https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-						dep status
-						dep ensure -v
+                        # copy the code into the new directory for go compile
+                        cp -r $DEFAULT_CODE_DIRECTORY/* .
+                        echo $DEFAULT_CODE_DIRECTORY >> $DEFAULT_WORKSPACE_DIR_FILE
 
-						# now compile the code
-						export HOME=$JENKINS_HOME
-						export GOCACHE="off"
-						export GOARCH=amd64
-						GOOS=darwin go build -ldflags="-s -w" -o codewind-installer-macos
-  						GOOS=windows go build -ldflags="-s -w" -o codewind-installer-win.exe
-  						GOOS=linux go build -ldflags="-s -w" -o codewind-installer-linux
-  						chmod -v +x codewind-installer-*
+                        # get dep and run it
+                        wget -O - https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+                        dep status
+                        dep ensure -v
 
-					'''
-				}
-			}
-		}
+                        # now compile the code
+                        export HOME=$JENKINS_HOME
+                        export GOCACHE="off"
+                        export GOARCH=amd64
+                        GOOS=darwin go build -ldflags="-s -w" -o codewind-installer-macos
+                        GOOS=windows go build -ldflags="-s -w" -o codewind-installer-win.exe
+                        GOOS=linux go build -ldflags="-s -w" -o codewind-installer-linux
+                        chmod -v +x codewind-installer-*
 
-		stage('Test') {
+                    '''
+                }
+            }
+        }
+
+        stage('Test') {
             steps {
                 echo 'Testing to be defined.'
             }
@@ -86,42 +87,41 @@ spec:
 
         stage('Upload') {
           steps {
-				script {
-					sh '''
-						# switch to the code go directory
-						cd ../../$CODE_DIRECTORY_FOR_GO
-						echo $(pwd)
-						if [ -d codewind-installer ]; then
-							rm -rf codewind-installer
-						fi
-						mkdir codewind-installer
+                script {
+                    sh '''
+                        # switch to the code go directory
+                        cd ../../$CODE_DIRECTORY_FOR_GO
+                        echo $(pwd)
+                        if [ -d codewind-installer ]; then
+                            rm -rf codewind-installer
+                        fi
+                        mkdir codewind-installer
 
-						TIMESTAMP="$(date +%F-%H%M)"
-						# WINDOWS EXE: Submit Windows unsigned.exe and save signed output to signed.exe
+                        TIMESTAMP="$(date +%F-%H%M)"
+                        # WINDOWS EXE: Submit Windows unsigned.exe and save signed output to signed.exe
 
-	                    # only sign windows exe if not a pull request
-						if [ -z $CHANGE_ID ]; then
-                        	curl -o codewind-installer/codewind-installer-win-${TIMESTAMP}.exe  -F file=@codewind-installer-win.exe http://build.eclipse.org:31338/winsign.php
-							rm codewind-installer-win.exe
-						fi
-						# move other executable to codewind-installer directoryand add timestamp to the name
-						for fileid in codewind-installer-*; do
-        					mv -v $fileid codewind-installer/${fileid}-$TIMESTAMP
-						done
+                        # only sign windows exe if not a pull request
+                        if [ -z $CHANGE_ID ]; then
+                            curl -o codewind-installer/codewind-installer-win-${TIMESTAMP}.exe  -F file=@codewind-installer-win.exe http://build.eclipse.org:31338/winsign.php
+                            rm codewind-installer-win.exe
+                        fi
+                        # move other executable to codewind-installer directoryand add timestamp to the name
+                        for fileid in codewind-installer-*; do
+                            mv -v $fileid codewind-installer/${fileid}-$TIMESTAMP
+                        done
 
-						DEFAULT_WORKSPACE_DIR=$(cat $DEFAULT_WORKSPACE_DIR_FILE)
-						cp -r codewind-installer $DEFAULT_WORKSPACE_DIR
-
-					'''
-					// stash the executables so they are avaialable outside of this agent
-					dir('codewind-installer') {
-						stash includes: '**', name: 'EXECUTABLES'
-					}
-				}
-			}
+                        DEFAULT_WORKSPACE_DIR=$(cat $DEFAULT_WORKSPACE_DIR_FILE)
+                        cp -r codewind-installer $DEFAULT_WORKSPACE_DIR
+                    '''
+                    // stash the executables so they are avaialable outside of this agent
+                    dir('codewind-installer') {
+                        stash includes: '**', name: 'EXECUTABLES'
+                    }
+                }
+            }
         }
-		stage('Deploy') {
-			// This when clause disables PR build uploads; you may comment this out if you want your build uploaded.
+        stage('Deploy') {
+            // This when clause disables PR build uploads; you may comment this out if you want your build uploaded.
             when {
                 beforeAgent true
                 not {
@@ -129,41 +129,71 @@ spec:
                 }
             }
 
-			agent any
-           	steps {
-               	sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
+            agent any
+               steps {
+                   sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
                 println("Deploying codewind-installer to download area...")
-				sh '''
-		 			if [ -d codewind-installer ]; then
-						rm -rf codewind-installer
-					fi
-		 			mkdir codewind-installer
-				'''
-				// get the stashed executables
-		 		dir ('codewind-installer') {
-		 			unstash 'EXECUTABLES'
-		 		}
                 sh '''
-					WORKSPACE=$PWD
-					ls -la ${WORKSPACE}/codewind-installer/*
-					if [ -z $CHANGE_ID ]; then
-    					UPLOAD_DIR="$GIT_BRANCH/$BUILD_ID"
-					else
-    					UPLOAD_DIR="pr/$CHANGE_ID/$BUILD_ID"
-					fi
-                 	ssh genie.codewind@projects-storage.eclipse.org rm -rf /home/data/httpd/download.eclipse.org/codewind/codewind-installer/${UPLOAD_DIR}
-            		ssh genie.codewind@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/codewind/codewind-installer/${UPLOAD_DIR}
-                    scp -r ${WORKSPACE}/codewind-installer/* genie.codewind@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/codewind/codewind-installer/${UPLOAD_DIR}
+                    if [ -d codewind-installer ]; then
+                        rm -rf codewind-installer
+                    fi
+                    mkdir codewind-installer
+                '''
+                // get the stashed executables
+                 dir ('codewind-installer') {
+                     unstash 'EXECUTABLES'
+                 }
+                sh '''
+                    export REPO_NAME="codewind-installer"
+                    export OUTPUT_DIR="$WORKSPACE/dev/ant_build/artifacts"
+                    export DOWNLOAD_AREA_URL="https://download.eclipse.org/codewind/$REPO_NAME"
+                    export LATEST_DIR="latest"
+                    export BUILD_INFO="build_info.properties"
+                    export sshHost="genie.codewind@projects-storage.eclipse.org"
+                    export deployDir="/home/data/httpd/download.eclipse.org/codewind/$REPO_NAME"
+                    export INSTALLER_LINUX="codewind-installer-linux"
+                    export INSTALLER_MACOS="codewind-installer-macos"
+                    export INSTALLER_WIN="codewind-installer-win"
+                    
+                    WORKSPACE=$PWD
+   
+                    ls -la ${WORKSPACE}/$REPO_NAME/*
+                    
+                    UPLOAD_DIR="$GIT_BRANCH/$BUILD_ID"
+                    BUILD_URL="$DOWNLOAD_AREA_URL/$UPLOAD_DIR"
+                    
+                    ssh $sshHost rm -rf $deployDir/${UPLOAD_DIR}
+                    ssh $sshHost mkdir -p $deployDir/${UPLOAD_DIR}
+
+                    ssh $sshHost rm -rf $deployDir/$GIT_BRANCH/$LATEST_DIR
+                    ssh $sshHost mkdir -p $deployDir/$GIT_BRANCH/$LATEST_DIR
+
+                    scp ${WORKSPACE}/$REPO_NAME/* $sshHost:$deployDir/${UPLOAD_DIR}
+
+                    mv ${WORKSPACE}/$REPO_NAME/$INSTALLER_LINUX-* ${WORKSPACE}/$REPO_NAME/$INSTALLER_LINUX
+                    mv ${WORKSPACE}/$REPO_NAME/$INSTALLER_MACOS-* ${WORKSPACE}/$REPO_NAME/$INSTALLER_MACOS
+                    mv ${WORKSPACE}/$REPO_NAME/$INSTALLER_WIN-* ${WORKSPACE}/$REPO_NAME/$INSTALLER_WIN.exe
+
+                    SHA1_LINUX=$(sha1sum $INSTALLER_LINUX | cut -d ' ' -f 1)
+                    echo "build_info.linux.SHA-1=${SHA1_LINUX}" >> ${WORKSPACE}/$REPO_NAME/$BUILD_INFO
+
+                    SHA1_MACOS=$(sha1sum $INSTALLER_MACOS | cut -d ' ' -f 1)
+                    echo "build_info.macos.SHA-1=${SHA1_MACOS}" >> ${WORKSPACE}/$REPO_NAME/$BUILD_INFO
+
+                    SHA1_WIN=$(sha1sum $INSTALLER_WIN.exe | cut -d ' ' -f 1)
+                    echo "build_info.win.SHA-1=${SHA1_WIN}" >> ${WORKSPACE}/$REPO_NAME/$BUILD_INFO
+
+                    scp -r ${WORKSPACE}/$REPO_NAME/* $sshHost:$deployDir/$GIT_BRANCH/$LATEST_DIR
                   '''
                }
            }
-		}
+        }
 
-	}
+    }
 
-	post {
+    post {
         success {
-			echo 'Build SUCCESS'
+            echo 'Build SUCCESS'
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -174,13 +174,14 @@ spec:
                     mv ${WORKSPACE}/$REPO_NAME/$INSTALLER_MACOS-* ${WORKSPACE}/$REPO_NAME/$INSTALLER_MACOS
                     mv ${WORKSPACE}/$REPO_NAME/$INSTALLER_WIN-* ${WORKSPACE}/$REPO_NAME/$INSTALLER_WIN.exe
 
-                    SHA1_LINUX=$(sha1sum $INSTALLER_LINUX | cut -d ' ' -f 1)
+                    echo "build_info.url=$BUILD_URL" >> ${WORKSPACE}/$REPO_NAME/$BUILD_INFO
+                    SHA1_LINUX=$(sha1sum ${WORKSPACE}/$REPO_NAME/$INSTALLER_LINUX | cut -d ' ' -f 1)
                     echo "build_info.linux.SHA-1=${SHA1_LINUX}" >> ${WORKSPACE}/$REPO_NAME/$BUILD_INFO
 
-                    SHA1_MACOS=$(sha1sum $INSTALLER_MACOS | cut -d ' ' -f 1)
+                    SHA1_MACOS=$(sha1sum ${WORKSPACE}/$REPO_NAME/$INSTALLER_MACOS | cut -d ' ' -f 1)
                     echo "build_info.macos.SHA-1=${SHA1_MACOS}" >> ${WORKSPACE}/$REPO_NAME/$BUILD_INFO
 
-                    SHA1_WIN=$(sha1sum $INSTALLER_WIN.exe | cut -d ' ' -f 1)
+                    SHA1_WIN=$(sha1sum ${WORKSPACE}/$REPO_NAME/$INSTALLER_WIN.exe | cut -d ' ' -f 1)
                     echo "build_info.win.SHA-1=${SHA1_WIN}" >> ${WORKSPACE}/$REPO_NAME/$BUILD_INFO
 
                     scp -r ${WORKSPACE}/$REPO_NAME/* $sshHost:$deployDir/$GIT_BRANCH/$LATEST_DIR

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ $ brew upgrade dep
 
 Subcommands:</br>
 
-`list/ls` - Shows a list of commands or help for one command
+`list/ls` - List available templates
 
 ## help
 

--- a/README.md
+++ b/README.md
@@ -83,49 +83,58 @@ $ brew upgrade dep
 
 |Command         |Alias         |Usage                                                           |
 |----------------|--------------|----------------------------------------------------------------|
-|project         |-             |'Manage Codewind projects'                                      |
+|project         |`-`           |'Manage Codewind projects'                                      |
 |install         |`in`          |'Pull pfe, performance & initialize images from dockerhub'      |
-|start           |-             |'Start the Codewind containers'                                 |
-|status          |-             |'Print the installation status of Codewind'                     |
-|stop            |-             |'Stop the running Codewind containers'                          |
-|stop-all        |-             |'Stop all of the Codewind and project containers'               |
+|start           |`-`           |'Start the Codewind containers'                                 |
+|status          |`-`           |'Print the installation status of Codewind'                     |
+|stop            |`-`           |'Stop the running Codewind containers'                          |
+|stop-all        |`-`           |'Stop all of the Codewind and project containers'               |
 |remove          |`rm`          |'Remove Codewind/Project docker images and the codewind network'|
+|templates       |`-`           |'Manage project templates'                                      |
 |help            |`h`           |'Shows a list of commands or help for one command'              |
 
 ## CLI Command Options
 
-### project
+## project
 
-`--url/-u` - URL of project to download
+`--url/-u <value>` - URL of project to download
 
-### install
+## install
 
-`--tag/t` - Dockerhub image tag (default: "latest")</br>
+`--tag/t <value>` - Dockerhub image tag (default: "latest")</br>
 `--json/-j` - Specify terminal output
 
-### start
+## start
 
-`--tag/-t` - Dockerhub image tag (default: "latest")</br>
+`--tag/-t <value>` - Dockerhub image tag (default: "latest")</br>
 `--debug/-d` - Add debug output
 
-### status
+## status
 
 `--json/-j` - Specify terminal output
 
-### stop
+## stop
 
 >**Note:** No additional flags
 
-### stop-all
+## stop-all
 
 >**Note:** No additional flags
 
-### remove
+## remove
 
-`--tag/-t` - Dockerhub image tag </br>
->**Note:** Specifying no tag will remove all Codewind images installed on the host machine 
+`--tag/-t <value>` - Dockerhub image tag.</br>
+**Note:** Failing to specify a `--tag`, will remove all Codewind images on the host machine.
 
-### help
+## templates
+
+>**Note:** No additional flags
+
+Subcommands:</br>
+
+`list/ls` - Shows a list of commands or help for one command
+
+## help
 
 `--help/-h` - Shows a list of commands or help for one command
 

--- a/README.md
+++ b/README.md
@@ -83,14 +83,14 @@ $ brew upgrade dep
 
 |Command         |Alias         |Usage                                                           |
 |----------------|--------------|----------------------------------------------------------------|
-|project         |`-`           |'Manage Codewind projects'                                      |
+|project         |              |'Manage Codewind projects'                                      |
 |install         |`in`          |'Pull pfe, performance & initialize images from dockerhub'      |
-|start           |`-`           |'Start the Codewind containers'                                 |
-|status          |`-`           |'Print the installation status of Codewind'                     |
-|stop            |`-`           |'Stop the running Codewind containers'                          |
-|stop-all        |`-`           |'Stop all of the Codewind and project containers'               |
+|start           |              |'Start the Codewind containers'                                 |
+|status          |              |'Print the installation status of Codewind'                     |
+|stop            |              |'Stop the running Codewind containers'                          |
+|stop-all        |              |'Stop all of the Codewind and project containers'               |
 |remove          |`rm`          |'Remove Codewind/Project docker images and the codewind network'|
-|templates       |`-`           |'Manage project templates'                                      |
+|templates       |              |'Manage project templates'                                      |
 |help            |`h`           |'Shows a list of commands or help for one command'              |
 
 ## CLI Command Options
@@ -101,7 +101,7 @@ $ brew upgrade dep
 
 ## install
 
-`--tag/t <value>` - Dockerhub image tag (default: "latest")</br>
+`--tag/-t <value>` - Dockerhub image tag (default: "latest")</br>
 `--json/-j` - Specify terminal output
 
 ## start

--- a/README.md
+++ b/README.md
@@ -67,9 +67,16 @@ $ brew upgrade dep
 ## Unit testing
 
 1. Clone the `codewind-installer` repository.
-2. Use the `cd` command to go to the test directory. The `utils.go` tests are located in the `utils/utils_test.go` file.
+2. Use the `cd` command to go to a directory with test files in. For example, the `utils.go` tests are located in the `utils/utils_test.go` file.
 3. To run the tests, enter the `go test -v` command in the command line window and wait for the tests to finish.
 4. For any other unit tests, the same steps apply, but the directory might change.
+
+## Bats-core testing
+
+1. Clone the `codewind-installer` repository.
+2. Use the `cd` command to go to the top level project directory.
+3. Ensure your system environment is clean by having no Codewind images installed or containers running.
+4. To run the tests, enter the `bats integration.bats` command in the command line window and wait for the tests to finish.
 
 ## Contributing
 
@@ -77,3 +84,53 @@ Submit issues and contributions:
 
 1. [Submitting issues](https://github.com/eclipse/codewind/issues)
 2. [Contributing](CONTRIBUTING.md)
+
+## CLI Commands
+
+|Command         |Alias         |Usage                                                           |
+|----------------|--------------|----------------------------------------------------------------|
+|project         |-             |'Manage Codewind projects'                                      |
+|install         |`in`          |'Pull pfe, performance & initialize images from dockerhub'      |
+|start           |-             |'Start the Codewind containers'                                 |
+|status          |-             |'Print the installation status of Codewind'                     |
+|stop            |-             |'Stop the running Codewind containers'                          |
+|stop-all        |-             |'Stop all of the Codewind and project containers'               |
+|remove          |`rm`          |'Remove Codewind/Project docker images and the codewind network'|
+|help            |`h`           |'Shows a list of commands or help for one command'              |
+
+## CLI Command Options
+
+### project
+
+`--url/-u` - URL of project to download
+
+### install
+
+`--tag/t` - Dockerhub image tag (default: "latest")</br>
+`--json/-j` - Specify terminal output
+
+### start
+
+`--tag/-t` - Dockerhub image tag (default: "latest")</br>
+`--debug/-d` - Add debug output
+
+### status
+
+`--json/-j` - Specify terminal output
+
+### stop
+
+>**Note:** No additional flags
+
+### stop-all
+
+>**Note:** No additional flags
+
+### remove
+
+`--tag/-t` - Dockerhub image tag </br>
+>**Note:** Specifying no tag will remove all Codewind images installed on the host machine 
+
+### help
+
+`--help/-h` - Shows a list of commands or help for one command

--- a/README.md
+++ b/README.md
@@ -73,17 +73,11 @@ $ brew upgrade dep
 
 ## Bats-core testing
 
-1. Clone the `codewind-installer` repository.
-2. Use the `cd` command to go to the top level project directory.
-3. Ensure your system environment is clean by having no Codewind images installed or containers running.
-4. To run the tests, enter the `bats integration.bats` command in the command line window and wait for the tests to finish.
-
-## Contributing
-
-Submit issues and contributions:
-
-1. [Submitting issues](https://github.com/eclipse/codewind/issues)
-2. [Contributing](CONTRIBUTING.md)
+1. Set up your environment by installing bats-core as per the bats-core instructions found at <https://github.com/bats-core/bats-core>.
+2. Clone the `codewind-installer` repository.
+3. Use the `cd` command to go to the top level project directory.
+4. Ensure your system environment is clean by having no Codewind images installed or containers running.
+5. To run the tests, enter the `bats integration.bats` command in the command line window and wait for the tests to finish.
 
 ## CLI Commands
 
@@ -134,3 +128,10 @@ Submit issues and contributions:
 ### help
 
 `--help/-h` - Shows a list of commands or help for one command
+
+## Contributing
+
+Submit issues and contributions:
+
+1. [Submitting issues](https://github.com/eclipse/codewind/issues)
+2. [Contributing](CONTRIBUTING.md)

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -27,7 +27,7 @@ const healthEndpoint = "/api/v1/environment"
 //Commands for the installer
 func Commands() {
 	app := cli.NewApp()
-	app.Name = "Codewind Installer"
+	app.Name = "codewind-installer"
 	app.Version = versionNum
 	app.Usage = "Start, Stop and Remove Codewind"
 
@@ -159,7 +159,7 @@ func Commands() {
 					Aliases: []string{"ls"},
 					Usage:   "list available templates",
 					Action: func(c *cli.Context) error {
-						ListTemplates()
+						ListTemplates(c)
 						return nil
 					},
 				},

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -31,6 +31,14 @@ func Commands() {
 	app.Version = versionNum
 	app.Usage = "Start, Stop and Remove Codewind"
 
+	// Global Flags
+	app.Flags = []cli.Flag{
+		cli.BoolFlag{
+			Name:  "insecure",
+			Usage: "disable certificate checking",
+		},
+	}
+
 	// create commands
 	app.Commands = []cli.Command{
 
@@ -143,13 +151,13 @@ func Commands() {
 		},
 
 		{
-			Name:    "templates",
-			Usage:   "Manage project templates",
+			Name:  "templates",
+			Usage: "Manage project templates",
 			Subcommands: []cli.Command{
 				{
-					Name:  "list",
+					Name:    "list",
 					Aliases: []string{"ls"},
-					Usage: "list available templates",
+					Usage:   "list available templates",
 					Action: func(c *cli.Context) error {
 						ListTemplates()
 						return nil
@@ -168,6 +176,77 @@ func Commands() {
 					Usage: "list available template repos",
 					Action: func(c *cli.Context) error {
 						ListTemplateRepos()
+						return nil
+					},
+				},
+			},
+		},
+
+		//  Deployment maintenance //
+		{
+			Name:    "deployments",
+			Aliases: []string{"dep"},
+			Usage:   "Maintain local deployments list",
+			Subcommands: []cli.Command{
+				{
+					Name:    "add",
+					Aliases: []string{"a"},
+					Usage:   "Add a new deployment to the list",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "name", Usage: "A reference name", Required: true},
+						cli.StringFlag{Name: "label", Usage: "A displayable name", Required: false},
+						cli.StringFlag{Name: "url", Usage: "The ingress url of the PFE instance", Required: true},
+					},
+					Action: func(c *cli.Context) error {
+						AddDeploymentToList(c)
+						return nil
+					},
+				},
+				{
+					Name:    "remove",
+					Aliases: []string{"rm"},
+					Usage:   "Remove a deployment from the list",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "name", Usage: "The reference name of the deployment to be removed", Required: true},
+					},
+					Action: func(c *cli.Context) error {
+						if c.NumFlags() != 1 {
+						} else {
+							RemoveDeploymentFromList(c)
+						}
+						return nil
+					},
+				},
+				{
+					Name:    "target",
+					Aliases: []string{"t"},
+					Usage:   "Show/Change the current target deployment",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "name", Usage: "The deployment name of a new target"},
+					},
+					Action: func(c *cli.Context) error {
+						if c.NumFlags() == 0 {
+							ListTargetDeployment()
+						} else {
+							SetTargetDeployment(c)
+						}
+						return nil
+					},
+				},
+				{
+					Name:    "list",
+					Aliases: []string{"ls"},
+					Usage:   "List known deployments",
+					Action: func(c *cli.Context) error {
+						ListDeployments()
+						return nil
+					},
+				},
+				{
+					Name:  "reset",
+					Usage: "Resets the deployments list",
+					Action: func(c *cli.Context) error {
+						ResetDeploymentsFile()
 						return nil
 					},
 				},

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -132,12 +132,7 @@ func Commands() {
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "tag, t",
-					Value: "latest",
 					Usage: "dockerhub image tag",
-				},
-				cli.BoolFlag{
-					Name:  "alltags, at",
-					Usage: "remove all tagged codewind images",
 				},
 			},
 			Usage: "Remove Codewind/Project docker images and the codewind network",

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -143,13 +143,13 @@ func Commands() {
 		},
 
 		{
-			Name:    "templates",
-			Usage:   "Manage project templates",
+			Name:  "templates",
+			Usage: "Manage project templates",
 			Subcommands: []cli.Command{
 				{
-					Name:  "list",
+					Name:    "list",
 					Aliases: []string{"ls"},
-					Usage: "list available templates",
+					Usage:   "list available templates",
 					Action: func(c *cli.Context) error {
 						ListTemplates()
 						return nil

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -129,9 +129,20 @@ func Commands() {
 		{
 			Name:    "remove",
 			Aliases: []string{"rm"},
-			Usage:   "Remove Codewind/Project docker images and the codewind network",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "tag, t",
+					Value: "latest",
+					Usage: "dockerhub image tag",
+				},
+				cli.BoolFlag{
+					Name:  "alltags, at",
+					Usage: "remove all tagged codewind images",
+				},
+			},
+			Usage: "Remove Codewind/Project docker images and the codewind network",
 			Action: func(c *cli.Context) error {
-				RemoveCommand()
+				RemoveCommand(c)
 				return nil
 			},
 		},

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -157,7 +157,19 @@ func Commands() {
 				{
 					Name:    "list",
 					Aliases: []string{"ls"},
-					Usage:   "list available templates",
+					Usage: "List available templates",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "projectStyle",
+							Value: "Codewind",
+							Usage: "Filter by project style",
+						},
+						cli.StringFlag{
+							Name:  "showEnabledOnly",
+							Value: "false",
+							Usage: "Filter by whether a template is enabled or not",
+						},
+					},
 					Action: func(c *cli.Context) error {
 						ListTemplates(c)
 						return nil
@@ -165,7 +177,7 @@ func Commands() {
 				},
 				{
 					Name:  "styles",
-					Usage: "list available template styles",
+					Usage: "List available template styles",
 					Action: func(c *cli.Context) error {
 						ListTemplateStyles()
 						return nil
@@ -173,7 +185,7 @@ func Commands() {
 				},
 				{
 					Name:  "repos",
-					Usage: "list available template repos",
+					Usage: "List available template repos",
 					Action: func(c *cli.Context) error {
 						ListTemplateRepos()
 						return nil

--- a/actions/deployment.go
+++ b/actions/deployment.go
@@ -156,8 +156,7 @@ func SetTargetDeployment(c *cli.Context) {
 		}
 	}
 	if foundName == "" {
-		log.Println("Unable to change deployment. '" + newTargetName + "' has no matching configuration")
-		os.Exit(1)
+		log.Fatal("Unable to change deployment. '" + newTargetName + "' has no matching configuration")
 	}
 
 	data.Active = foundName
@@ -182,8 +181,7 @@ func AddDeploymentToList(c *cli.Context) {
 	// check the name is not already in use
 	for i := 0; i < len(data.Deployments); i++ {
 		if strings.EqualFold(name, data.Deployments[i].Name) {
-			log.Println("Deployment '" + name + "' already exists, to update:  first remove, then add")
-			os.Exit(1)
+			log.Fatal("Deployment '" + name + "' already exists, to update:  first remove, then add")
 		}
 	}
 
@@ -209,8 +207,7 @@ func AddDeploymentToList(c *cli.Context) {
 func RemoveDeploymentFromList(c *cli.Context) {
 	name := c.String("name")
 	if strings.EqualFold(name, "local") {
-		log.Println("Local is a required deployment and can not be removed")
-		os.Exit(1)
+		log.Fatal("Local is a required deployment and can not be removed")
 	}
 	data, err, errCode := loadDeploymentsConfigFile()
 	errors.CheckErr(err, errCode, "Unable to process the deployments config file")

--- a/actions/deployment.go
+++ b/actions/deployment.go
@@ -25,7 +25,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-func getDeploymentConfigFilename() string {
+func getDeploymentConfigPath() string {
 	const GOOS string = runtime.GOOS
 	homeDir := ""
 	if GOOS == "windows" {
@@ -33,7 +33,11 @@ func getDeploymentConfigFilename() string {
 	} else {
 		homeDir = os.Getenv("HOME")
 	}
-	return path.Join(homeDir, ".codewind", "config", "deployments.json")
+	return path.Join(homeDir, ".codewind", "config")
+}
+
+func getDeploymentConfigFilename() string {
+	return path.Join(getDeploymentConfigPath(), "deployments.json")
 }
 
 type DeploymentConfig struct {
@@ -51,8 +55,9 @@ type Deployment struct {
 * Check the config file exist, if it does not then create a new default configuration
  */
 func InitDeploymentConfigIfRequired() {
-	_, err, code := loadDeploymentsConfigFile()
-	if err != nil && code == 207 {
+	_, err := os.Stat(getDeploymentConfigFilename())
+	if os.IsNotExist(err) {
+		os.Mkdir(getDeploymentConfigPath(), 0777)
 		ResetDeploymentsFile()
 	}
 }

--- a/actions/deployment.go
+++ b/actions/deployment.go
@@ -1,0 +1,240 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package actions
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"runtime"
+	"strings"
+
+	"github.com/eclipse/codewind-installer/errors"
+	"github.com/eclipse/codewind-installer/utils"
+	"github.com/urfave/cli"
+)
+
+func getDeploymentConfigFilename() string {
+	const GOOS string = runtime.GOOS
+	homeDir := ""
+	if GOOS == "windows" {
+		homeDir = os.Getenv("USERPROFILE")
+	} else {
+		homeDir = os.Getenv("HOME")
+	}
+	return path.Join(homeDir, ".codewind", "config", "deployments.json")
+}
+
+type DeploymentConfig struct {
+	Active      string       `json:"active"`
+	Deployments []Deployment `json:"deployments"`
+}
+
+type Deployment struct {
+	Name  string `json:"name"`
+	Label string `json:"label"`
+	Url   string `json:"url"`
+}
+
+/**
+* Check the file exist, if it does not, create a new configuration
+ */
+func initDeploymentConfigIfRequired() {
+	_, err, code := loadDeploymentsConfigFile()
+	if err != nil && code == 207 {
+		ResetDeploymentsFile()
+	}
+}
+
+/***
+ * ResetDeploymentsFile
+ * Creates a new / overwrites deployment config file with a default single local Codewind deployment
+ */
+func ResetDeploymentsFile() {
+	// create the default local deployment
+	initialConfig := DeploymentConfig{
+		Active: "local",
+		Deployments: []Deployment{
+			Deployment{
+				Name:  "local",
+				Label: "Codewind local deployment",
+				Url:   "tbd",
+			},
+		},
+	}
+	body, err := json.MarshalIndent(initialConfig, "", "\t")
+	errors.CheckErr(err, 208, "Unable to format deployments file")
+	saveErr := ioutil.WriteFile(getDeploymentConfigFilename(), body, 0644)
+	errors.CheckErr(saveErr, 203, "Unable to save the deployments config file")
+}
+
+/***
+ * Load the deployments configuration file from disk
+ * returns:  the contents of the file, an error, an error code
+ */
+func loadDeploymentsConfigFile() (*DeploymentConfig, error, int) {
+	file, err := ioutil.ReadFile(getDeploymentConfigFilename())
+	if err != nil {
+		return nil, err, 207
+	}
+	data := DeploymentConfig{}
+	err = json.Unmarshal([]byte(file), &data)
+	if err != nil {
+		return nil, err, 208
+	}
+	return &data, nil, 0
+}
+
+/***
+ * Save the deployments configuration file to disk
+ * returns:  an error,  and error code
+ */
+func saveDeploymentsConfigFile() (error, int) {
+	file, err := ioutil.ReadFile(getDeploymentConfigFilename())
+	if err != nil {
+		return err, 207
+	}
+	data := DeploymentConfig{}
+	err = json.Unmarshal([]byte(file), &data)
+	if err != nil {
+		return err, 208
+	}
+	return nil, 0
+}
+
+/***
+ * FindTargetDeployment
+ * returns:  The single active deployment
+ */
+func FindTargetDeployment() *Deployment {
+	data, err, errCode := loadDeploymentsConfigFile()
+	errors.CheckErr(err, errCode, "Unable to process the deployments config file")
+	activeID := data.Active
+	for i := 0; i < len(data.Deployments); i++ {
+		if strings.EqualFold(activeID, data.Deployments[i].Name) {
+			return &data.Deployments[i]
+		}
+	}
+	return nil
+}
+
+/***
+ * GetDeploymentConfig
+ * returns:  The entire Deployment configuration contents
+ */
+func GetDeploymentsConfig() *DeploymentConfig {
+	data, err, errCode := loadDeploymentsConfigFile()
+	errors.CheckErr(err, errCode, "Unable to process the deployments config file")
+	return data
+}
+
+/**
+* Set active deployment
+* If the deployment is unknown the command will fail with an error message
+ */
+func SetTargetDeployment(c *cli.Context) {
+	newTargetName := c.String("name")
+	data, err, errCode := loadDeploymentsConfigFile()
+	errors.CheckErr(err, errCode, "Unable to process the deployments config file")
+	foundName := ""
+
+	for i := 0; i < len(data.Deployments); i++ {
+		if strings.EqualFold(newTargetName, data.Deployments[i].Name) {
+			foundName = data.Deployments[i].Name
+			break
+		}
+	}
+	if foundName == "" {
+		log.Println("Unable to change deployment. '" + newTargetName + "' has no matching configuration")
+		os.Exit(1)
+	}
+
+	data.Active = foundName
+	body, err := json.MarshalIndent(data, "", "\t")
+	errors.CheckErr(err, 208, "Unable to format deployments file")
+	saveErr := ioutil.WriteFile(getDeploymentConfigFilename(), body, 0644)
+	errors.CheckErr(saveErr, 203, "Unable to save the deployments config file")
+}
+
+/**
+ * AddDeploymentToList
+ * Adds a new deployment to the deployment config
+ */
+func AddDeploymentToList(c *cli.Context) {
+	name := strings.ToLower(c.String("name"))
+	label := c.String("label")
+	url := c.String("url")
+
+	data, err, errCode := loadDeploymentsConfigFile()
+	errors.CheckErr(err, errCode, "Unable to process the deployments config file")
+
+	// check the name is not already in use
+	for i := 0; i < len(data.Deployments); i++ {
+		if strings.EqualFold(name, data.Deployments[i].Name) {
+			log.Println("Deployment '" + name + "' already exists, to update:  first remove, then add")
+			os.Exit(1)
+		}
+	}
+
+	// create the new deployment
+	newDeployment := Deployment{
+		Name:  name,
+		Label: label,
+		Url:   url,
+	}
+
+	// append it to the list
+	data.Deployments = append(data.Deployments, newDeployment)
+	body, err := json.MarshalIndent(data, "", "\t")
+	errors.CheckErr(err, 208, "Unable to format deployments file")
+	saveErr := ioutil.WriteFile(getDeploymentConfigFilename(), body, 0644)
+	errors.CheckErr(saveErr, 203, "Unable to save the deployments config file")
+}
+
+/**
+ * RemoveDeploymentFromList
+ * Removes a deployment from the list
+ */
+func RemoveDeploymentFromList(c *cli.Context) {
+	name := c.String("name")
+	if strings.EqualFold(name, "local") {
+		log.Println("Local is a required deployment and can not be removed")
+		os.Exit(1)
+	}
+	data, err, errCode := loadDeploymentsConfigFile()
+	errors.CheckErr(err, errCode, "Unable to process the deployments config file")
+	for i := 0; i < len(data.Deployments); i++ {
+		if strings.EqualFold(name, data.Deployments[i].Name) {
+			copy(data.Deployments[i:], data.Deployments[i+1:])
+			data.Deployments = data.Deployments[:len(data.Deployments)-1]
+		}
+	}
+	data.Active = "local"
+	body, err := json.MarshalIndent(data, "", "\t")
+	errors.CheckErr(err, 208, "Unable to format deployments file")
+	saveErr := ioutil.WriteFile(getDeploymentConfigFilename(), body, 0644)
+	errors.CheckErr(saveErr, 203, "Unable to save the deployments config file")
+}
+
+// Display the deployment details for the current target deployment
+func ListTargetDeployment() {
+	targetDeployment := FindTargetDeployment()
+	utils.PrettyPrintJSON(targetDeployment)
+}
+
+// Display saved deployments
+func ListDeployments() {
+	targetDeployment := GetDeploymentsConfig()
+	utils.PrettyPrintJSON(targetDeployment)
+}

--- a/actions/deployment.go
+++ b/actions/deployment.go
@@ -230,11 +230,19 @@ func RemoveDeploymentFromList(c *cli.Context) {
 // Display the deployment details for the current target deployment
 func ListTargetDeployment() {
 	targetDeployment := FindTargetDeployment()
-	utils.PrettyPrintJSON(targetDeployment)
+	if targetDeployment != nil {
+		utils.PrettyPrintJSON(targetDeployment)
+	} else {
+		log.Fatal("Unable to find a matching target - set one now using the target command")
+	}
 }
 
 // Display saved deployments
 func ListDeployments() {
-	targetDeployment := GetDeploymentsConfig()
-	utils.PrettyPrintJSON(targetDeployment)
+	deploymentConfig := GetDeploymentsConfig()
+	if deploymentConfig != nil && deploymentConfig.Deployments != nil && len(deploymentConfig.Deployments) > 0 {
+		utils.PrettyPrintJSON(deploymentConfig)
+	} else {
+		log.Fatal("Unable to any deployments - please run the reset command")
+	}
 }

--- a/actions/deployment.go
+++ b/actions/deployment.go
@@ -128,7 +128,9 @@ func FindTargetDeployment() *Deployment {
 	activeID := data.Active
 	for i := 0; i < len(data.Deployments); i++ {
 		if strings.EqualFold(activeID, data.Deployments[i].Name) {
-			return &data.Deployments[i]
+			targetDeployment := data.Deployments[i]
+			targetDeployment.Url = strings.TrimSuffix(targetDeployment.Url, "/")
+			return &targetDeployment
 		}
 	}
 	return nil
@@ -176,9 +178,12 @@ func SetTargetDeployment(c *cli.Context) {
  * Adds a new deployment to the deployment config
  */
 func AddDeploymentToList(c *cli.Context) {
-	name := strings.ToLower(c.String("name"))
-	label := c.String("label")
+	name := strings.TrimSpace(strings.ToLower(c.String("name")))
+	label := strings.TrimSpace(c.String("label"))
 	url := c.String("url")
+	if url != "" && len(strings.TrimSpace(url)) > 0 {
+		url = strings.TrimSuffix(url, "/")
+	}
 
 	data, err, errCode := loadDeploymentsConfigFile()
 	errors.CheckErr(err, errCode, "Unable to process the deployments config file")

--- a/actions/deployment.go
+++ b/actions/deployment.go
@@ -48,9 +48,9 @@ type Deployment struct {
 }
 
 /**
-* Check the file exist, if it does not, create a new configuration
+* Check the config file exist, if it does not then create a new default configuration
  */
-func initDeploymentConfigIfRequired() {
+func InitDeploymentConfigIfRequired() {
 	_, err, code := loadDeploymentsConfigFile()
 	if err != nil && code == 207 {
 		ResetDeploymentsFile()

--- a/actions/deployment_test.go
+++ b/actions/deployment_test.go
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package actions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetActiveDeployment(t *testing.T) {
+	t.Run("ActiveDeployment", func(t *testing.T) {
+		ResetDeploymentsFile()
+		result := FindTargetDeployment()
+		assert.Equal(t, "local", result.Name)
+		assert.Equal(t, "Codewind local deployment", result.Label)
+		assert.Equal(t, "tbd", result.Url)
+	})
+}
+
+func Test_GetDeploymentsConfig(t *testing.T) {
+	t.Run("GetDeploymentsConfig", func(t *testing.T) {
+		ResetDeploymentsFile()
+		result := GetDeploymentsConfig()
+		assert.Equal(t, "local", result.Active)
+		assert.Len(t, result.Deployments, 1)
+	})
+}
+
+//TODO:  add coverage

--- a/actions/install.go
+++ b/actions/install.go
@@ -37,6 +37,4 @@ func InstallCommand(c *cli.Context) {
 	}
 
 	fmt.Println("Image Tagging Successful")
-
-	initDeploymentConfigIfRequired()
 }

--- a/actions/install.go
+++ b/actions/install.go
@@ -37,4 +37,6 @@ func InstallCommand(c *cli.Context) {
 	}
 
 	fmt.Println("Image Tagging Successful")
+
+	initDeploymentConfigIfRequired()
 }

--- a/actions/project.go
+++ b/actions/project.go
@@ -27,13 +27,13 @@ type (
 	// ProjectType represents the information Codewind requires to build a project.
 	ProjectType struct {
 		Language  string `json:"language"`
-		BuildType string `json:"buildType"`
+		BuildType string `json:"projectType"`
 	}
 
 	// ValidationResponse represents the response to validating a project on the users filesystem.
 	ValidationResponse struct {
 		Status string      `json:"status"`
-		Path   string      `json:"path"`
+		Path   string      `json:"projectPath"`
 		Result ProjectType `json:"result"`
 	}
 )

--- a/actions/remove.go
+++ b/actions/remove.go
@@ -22,7 +22,6 @@ import (
 //RemoveCommand to remove all codewind and project images
 func RemoveCommand(c *cli.Context) {
 	tag := c.String("tag")
-	allTags := c.Bool("alltags")
 	imageArr := [4]string{}
 	imageArr[0] = "eclipse/codewind-pfe"
 	imageArr[1] = "eclipse/codewind-performance"
@@ -30,7 +29,7 @@ func RemoveCommand(c *cli.Context) {
 	imageArr[3] = "cw-"
 	networkName := "codewind"
 
-	if allTags == true {
+	if tag != "" {
 		for i := 0; i < len(imageArr); i++ {
 			if i == 3 {
 				break

--- a/actions/remove.go
+++ b/actions/remove.go
@@ -16,16 +16,28 @@ import (
 	"strings"
 
 	"github.com/eclipse/codewind-installer/utils"
+	"github.com/urfave/cli"
 )
 
 //RemoveCommand to remove all codewind and project images
-func RemoveCommand() {
+func RemoveCommand(c *cli.Context) {
+	tag := c.String("tag")
+	allTags := c.Bool("alltags")
 	imageArr := [4]string{}
 	imageArr[0] = "eclipse/codewind-pfe"
 	imageArr[1] = "eclipse/codewind-performance"
 	imageArr[2] = "eclipse/codewind-initialize"
 	imageArr[3] = "cw-"
 	networkName := "codewind"
+
+	if allTags == true {
+		for i := 0; i < len(imageArr); i++ {
+			if i == 3 {
+				break
+			}
+			imageArr[i] = imageArr[i] + "-amd64:" + tag
+		}
+	}
 
 	images := utils.GetImageList()
 

--- a/actions/status.go
+++ b/actions/status.go
@@ -15,13 +15,69 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
+	"github.com/eclipse/codewind-installer/apiroutes"
 	"github.com/eclipse/codewind-installer/utils"
 	"github.com/urfave/cli"
 )
 
 //StatusCommand to show the status
 func StatusCommand(c *cli.Context) {
+	targetDeployment := FindTargetDeployment()
+	if strings.EqualFold(targetDeployment.Name, "local") {
+		StatusCommandLocalDeployment(c)
+	} else {
+		StatusCommandRemoteDeployment(c, targetDeployment)
+	}
+}
+
+func StatusCommandRemoteDeployment(c *cli.Context, d *Deployment) {
+	jsonOutput := c.Bool("json")
+	apiResponse, err := apiroutes.GetAPIEnvironment(c, d.Url)
+	if err != nil {
+		if jsonOutput {
+			type status struct {
+				Status   string   `json:"status"`
+				Versions []string `json:"installed-versions"`
+			}
+			respStatus := &status{
+				Status:   "stopped",
+				Versions: []string{},
+			}
+			output, _ := json.Marshal(respStatus)
+			fmt.Println(string(output))
+		} else {
+			fmt.Println("Codewind remote deployment did not respond on " + d.Url)
+		}
+		os.Exit(0)
+	}
+
+	// Codewind responded
+	if jsonOutput {
+		type status struct {
+			Status   string   `json:"status"`
+			URL      string   `json:"url"`
+			Versions []string `json:"installed-versions"`
+			Started  []string `json:"started"`
+		}
+		versions := []string{}
+		resp := &status{
+			Status:   "started",
+			Versions: append(versions, apiResponse.Version),
+			Started:  append(versions, apiResponse.Version),
+			URL:      d.Url,
+		}
+		output, _ := json.Marshal(resp)
+		fmt.Println(string(output))
+	} else {
+		fmt.Println("Codewind is installed and running on: " + d.Url)
+	}
+	os.Exit(0)
+
+}
+
+func StatusCommandLocalDeployment(c *cli.Context) {
 	jsonOutput := c.Bool("json")
 	if utils.CheckContainerStatus() {
 		// STARTED

--- a/actions/status.go
+++ b/actions/status.go
@@ -14,6 +14,7 @@ package actions
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 
@@ -49,6 +50,7 @@ func StatusCommandRemoteDeployment(c *cli.Context, d *Deployment) {
 			fmt.Println(string(output))
 		} else {
 			fmt.Println("Codewind remote deployment did not respond on " + d.Url)
+			log.Println(err)
 		}
 		os.Exit(0)
 	}

--- a/actions/templates.go
+++ b/actions/templates.go
@@ -39,7 +39,8 @@ type (
 	}
 )
 
-// ListTemplates lists all project templates of which Codewind is aware.
+// ListTemplates lists project templates of which Codewind is aware.
+// Filter them by providing flags
 func ListTemplates(c *cli.Context) {
 	templates, err := GetTemplates(
 		c.String("projectStyle"),
@@ -72,7 +73,8 @@ func ListTemplateRepos() {
 	PrettyPrintJSON(repos)
 }
 
-// GetTemplates gets project templates from PFE's REST API
+// GetTemplates gets project templates from PFE's REST API.
+// Filter them using the function arguments
 func GetTemplates(projectStyle string, showEnabledOnly string) ([]Template, error) {
 	req, err := http.NewRequest("GET", config.PFEApiRoute + "templates", nil)
 	if err != nil {

--- a/actions/templates.go
+++ b/actions/templates.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	"github.com/eclipse/codewind-installer/config"
+	"github.com/urfave/cli"
 )
 
 type (
@@ -39,8 +40,11 @@ type (
 )
 
 // ListTemplates lists all project templates of which Codewind is aware.
-func ListTemplates() {
-	templates, err := GetTemplates()
+func ListTemplates(c *cli.Context) {
+	templates, err := GetTemplates(
+		c.String("projectStyle"),
+		c.String("showEnabledOnly"),
+	)
 	if err != nil {
 		log.Printf("Error getting templates: %q", err)
 		return
@@ -68,9 +72,23 @@ func ListTemplateRepos() {
 	PrettyPrintJSON(repos)
 }
 
-// GetTemplates gets all project templates from PFE's REST API
-func GetTemplates() ([]Template, error) {
-	resp, err := http.Get(config.PFEApiRoute + "templates")
+// GetTemplates gets project templates from PFE's REST API
+func GetTemplates(projectStyle string, showEnabledOnly string) ([]Template, error) {
+	req, err := http.NewRequest("GET", config.PFEApiRoute + "templates", nil)
+	if err != nil {
+		return nil, err
+	}
+	query := req.URL.Query()
+	if projectStyle != "" {
+		query.Add("projectStyle", projectStyle)
+	}
+	if showEnabledOnly != "" {
+		query.Add("showEnabledOnly", showEnabledOnly)
+	}
+    req.URL.RawQuery = query.Encode()
+
+	client := &http.Client{}
+    resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/actions/templates_test.go
+++ b/actions/templates_test.go
@@ -17,6 +17,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var numCodewindTemplates int = 8
+var numAppsodyTemplates int = 8
+var numTemplates int = numCodewindTemplates + numAppsodyTemplates
+
 func TestGetTemplates(t *testing.T) {
 	tests := map[string]struct {
 		inProjectStyle string
@@ -28,25 +32,25 @@ func TestGetTemplates(t *testing.T) {
 			inProjectStyle: "",
 			inShowEnabledOnly: "",
 			wantedType:     []Template{},
-			wantedLength:   8,
+			wantedLength:   numTemplates,
 		},
 		"filter templates by known style": {
 			inProjectStyle: "Codewind",
 			wantedType:   []Template{},
-			wantedLength: 8,
+			wantedLength: numCodewindTemplates,
 		},
 		"filter templates by unknown style": {
-			inProjectStyle: "Appsody",
+			inProjectStyle: "unknownStyle",
 			wantedType:   []Template{},
 			wantedLength: 0,
 		},
 		"filter templates by enabled templates": {
 			inShowEnabledOnly: "true",
 			wantedType:   []Template{},
-			wantedLength: 8,
+			wantedLength: numTemplates,
 		},
 		"filter templates by enabled templates of unknown style": {
-			inProjectStyle: "Appsody",
+			inProjectStyle: "unknownStyle",
 			inShowEnabledOnly: "false",
 			wantedType:     []Template{},
 			wantedLength:   0,
@@ -68,7 +72,7 @@ func TestGetTemplateStyles(t *testing.T) {
 		wantedErr error
 	}{
 		"success case": {
-			want:      []string{"Codewind"},
+			want:      []string{"Appsody", "Codewind"},
 			wantedErr: nil,
 		},
 	}

--- a/actions/templates_test.go
+++ b/actions/templates_test.go
@@ -19,22 +19,45 @@ import (
 
 func TestGetTemplates(t *testing.T) {
 	tests := map[string]struct {
-		wantedType   []Template
-		wantedLength int
-		wantedErr    error
+		inProjectStyle string
+		inShowEnabledOnly string
+		wantedType     []Template
+		wantedLength   int
 	}{
-		"success case": {
+		"get templates of all styles": {
+			inProjectStyle: "",
+			inShowEnabledOnly: "",
+			wantedType:     []Template{},
+			wantedLength:   8,
+		},
+		"filter templates by known style": {
+			inProjectStyle: "Codewind",
 			wantedType:   []Template{},
 			wantedLength: 8,
-			wantedErr:    nil,
+		},
+		"filter templates by unknown style": {
+			inProjectStyle: "Appsody",
+			wantedType:   []Template{},
+			wantedLength: 0,
+		},
+		"filter templates by enabled templates": {
+			inShowEnabledOnly: "true",
+			wantedType:   []Template{},
+			wantedLength: 8,
+		},
+		"filter templates by enabled templates of unknown style": {
+			inProjectStyle: "Appsody",
+			inShowEnabledOnly: "false",
+			wantedType:     []Template{},
+			wantedLength:   0,
 		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, err := GetTemplates()
+			got, err := GetTemplates(test.inProjectStyle, test.inShowEnabledOnly)
 			assert.IsType(t, test.wantedType, got)
 			assert.Equal(t, test.wantedLength, len(got))
-			assert.Equal(t, test.wantedErr, err)
+			assert.Nil(t, err)
 		})
 	}
 }

--- a/actions/templates_test.go
+++ b/actions/templates_test.go
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 package actions
 
 import (

--- a/apiroutes/environment.go
+++ b/apiroutes/environment.go
@@ -35,7 +35,7 @@ func GetAPIEnvironment(c *cli.Context, host string) (*Environment, error) {
 		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 
-	resp, err := http.Get(host + "/api/v1/environment")
+	resp, err := http.Get(host + "api/v1/environment")
 	if err != nil {
 		return nil, err
 	}

--- a/apiroutes/environment.go
+++ b/apiroutes/environment.go
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package apiroutes
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/urfave/cli"
+)
+
+type Environment struct {
+	RunningOnICP      bool   `json:"running_on_icp"`
+	UserString        string `json:"user_string"`
+	SocketNamespace   string `json:"socket_namespace"`
+	Version           string `json:"codewind_version"`
+	WorkspaceLocation string `json:"workspace_location"`
+	Platform          string `json:"os_platform"`
+}
+
+func GetAPIEnvironment(c *cli.Context, host string) (*Environment, error) {
+
+	if c.GlobalBool("insecure") {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+
+	resp, err := http.Get(host + "/api/v1/environment")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	byteArray, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var environment Environment
+	err = json.Unmarshal(byteArray, &environment)
+	if err != nil {
+		return nil, err
+	}
+	return &environment, nil
+}

--- a/apiroutes/environment.go
+++ b/apiroutes/environment.go
@@ -35,7 +35,7 @@ func GetAPIEnvironment(c *cli.Context, host string) (*Environment, error) {
 		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 
-	resp, err := http.Get(host + "api/v1/environment")
+	resp, err := http.Get(host + "/api/v1/environment")
 	if err != nil {
 		return nil, err
 	}

--- a/errors/error.go
+++ b/errors/error.go
@@ -52,6 +52,10 @@ func CheckErr(err error, code int, optMsg string) {
 		case 206:
 			// Do not want to exit if this is thrown
 			log.Print("DELETE_FILE_ERROR", "[", code, "]: ", err, ". ", optMsg)
+		case 207:
+			log.Fatal("READ_FILE_ERROR", "[", code, "]: ", err, ". ", optMsg)
+		case 208:
+			log.Fatal("PARSING_ERROR", "[", code, "]: ", err, ". ", optMsg)
 		case 300:
 			log.Fatal("APPLICATION_ERROR", "[", code, "]: ", err, ". ", optMsg)
 		case 400:

--- a/main.go
+++ b/main.go
@@ -14,5 +14,6 @@ package main
 import "github.com/eclipse/codewind-installer/actions"
 
 func main() {
+	actions.InitDeploymentConfigIfRequired()
 	actions.Commands()
 }

--- a/resources/test/liberty-project/pom.xml
+++ b/resources/test/liberty-project/pom.xml
@@ -1,0 +1,1 @@
+<groupId>org.eclipse.microprofile</groupId>

--- a/resources/test/spring-project/pom.xml
+++ b/resources/test/spring-project/pom.xml
@@ -1,0 +1,1 @@
+<groupId>org.springframework.boot</groupId>

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -345,7 +345,7 @@ func GetImageTags() []string {
 					tag = strings.Split(tag, ":")[1]
 					tagArr = append(tagArr, tag)
 				} else {
-					fmt.Println("No tag available. Defaulting to ''.")
+					log.Println("No tag available. Defaulting to ''")
 					tagArr = append(tagArr, "")
 				}
 			}

--- a/utils/download.go
+++ b/utils/download.go
@@ -1,11 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 package utils
 
 import (
 	"net/url"
 	"os"
+	"path"
 	"strings"
 	"time"
-	"path"
 )
 
 // DownloadFromURLThenExtract downloads files from a URL

--- a/utils/download_test.go
+++ b/utils/download_test.go
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 package utils
 
 import (

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -138,13 +138,14 @@ func DownloadFile(URL, destination string) error {
 	// Create the file
 	file, err := os.Create(destination)
 	if err != nil {
+		log.Println(err)
 		return err
 	}
 	defer file.Close()
 
 	// Write body to file
 	_, err = io.Copy(file, resp.Body)
-	fmt.Printf("Downloaded file from '%s' to '%s'\n", URL, destination)
+	log.Printf("Downloaded file from '%s' to '%s'\n", URL, destination)
 
 	return err
 }
@@ -191,7 +192,7 @@ func UnZip(filePath, destination string) error {
 			errors.CheckErr(err, 404, "")
 		}
 	}
-	fmt.Printf("Extracted file from '%s' to '%s'\n", filePath, destination)
+	log.Printf("Extracted file from '%s' to '%s'\n", filePath, destination)
 	return nil
 }
 

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -86,7 +86,7 @@ func DeleteTempFile(filePath string) (bool, error) {
 	return true, nil
 }
 
-// PingHealth - pings environment api over a 15 second to check if containers started
+// PingHealth - pings environment api every 15 seconds to check if containers started
 func PingHealth(healthEndpoint string) bool {
 	var started = false
 	fmt.Println("Waiting for Codewind to start")
@@ -256,4 +256,12 @@ func readFile(filePath string) (*os.File, error) {
 		return file, err
 	}
 	return file, nil
+}
+
+// PathExists returns whether a path exists on the local file system.
+func PathExists(path string) bool {
+	if _, err := os.Stat(path); err == nil {
+		return true
+	}
+	return false
 }

--- a/utils/project.go
+++ b/utils/project.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path"
 	"strings"
+
 	"github.com/eclipse/codewind-installer/errors"
 )
 
@@ -35,15 +36,15 @@ type CWSettings struct {
 // DetermineProjectInfo returns the language and build-type of a project
 func DetermineProjectInfo(projectPath string) (string, string) {
 	language, buildType := "unknown", "docker"
-	if _, err := os.Stat(path.Join(projectPath, "pom.xml")); err == nil {
+	if PathExists(path.Join(projectPath, "pom.xml")) {
 		language = "java"
 		buildType = determineJavaBuildType(projectPath)
 	}
-	if _, err := os.Stat(path.Join(projectPath, "package.json")); err == nil {
-		language = "nodejs"
-		buildType = "nodejs"
+	if PathExists(path.Join(projectPath, "package.json")) {
+		language = "node"
+		buildType = "node"
 	}
-	if _, err := os.Stat(path.Join(projectPath, "Package.swift")); err == nil {
+	if PathExists(path.Join(projectPath, "Package.swift")) {
 		language = "swift"
 		buildType = "swift"
 	}
@@ -54,19 +55,19 @@ func DetermineProjectInfo(projectPath string) (string, string) {
 // exist or is invalid
 func CheckProjectPath(projectPath string) {
 	if projectPath == "" {
-		log.Fatal("Project path has not been set")
+		log.Fatal("Project path not given")
 	}
 
-	if _, err := os.Stat(projectPath); os.IsNotExist(err) {
+	if !PathExists(projectPath) {
 		log.Fatal("Project not found at given path")
 	}
 }
 
 func determineJavaBuildType(projectPath string) string {
 	pathToPomXML := path.Join(projectPath, "pom.xml")
-	pomXMLContents, _err := ioutil.ReadFile(pathToPomXML)
+	pomXMLContents, err := ioutil.ReadFile(pathToPomXML)
 	// if there is an error reading the pom.xml, we build as docker
-	if _err != nil {
+	if err != nil {
 		return "docker"
 	}
 	pomXMLString := string(pomXMLContents)
@@ -81,11 +82,12 @@ func determineJavaBuildType(projectPath string) string {
 
 // WriteNewCwSettings writes a default .cw-settings file to the given path,
 // dependant on the build type of the project
-func WriteNewCwSettings(pathToCwSettings string, BuildType string,) {
+func WriteNewCwSettings(pathToCwSettings string, BuildType string) {
 	defaultCwSettings := getDefaultCwSettings()
 	cwSettings := addNonDefaultFieldsToCwSettings(defaultCwSettings, BuildType)
 	settings, err := json.MarshalIndent(cwSettings, "", "")
 	errors.CheckErr(err, 203, "")
+	// File permission 0644 grants read and write access to the owner
 	err = ioutil.WriteFile(pathToCwSettings, settings, 0644)
 }
 
@@ -119,8 +121,8 @@ func addNonDefaultFieldsToCwSettings(cwSettings CWSettings, ProjectType string) 
 	return cwSettings
 }
 
-func stringInSlice(a string, list []string) bool {
-	for _, b := range list {
+func stringInSlice(a string, slice []string) bool {
+	for _, b := range slice {
 		if b == a {
 			return true
 		}

--- a/utils/project_test.go
+++ b/utils/project_test.go
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package utils
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetermineProjectInfo(t *testing.T) {
+	tests := map[string]struct {
+		in            string
+		wantLanguage  string
+		wantBuildType string
+		wantedErr     error
+	}{
+		"success case: liberty project": {
+			in:            path.Join("..", "resources", "test", "liberty-project"),
+			wantLanguage:  "java",
+			wantBuildType: "liberty",
+		},
+		"success case: spring project": {
+			in:            path.Join("..", "resources", "test", "spring-project"),
+			wantLanguage:  "java",
+			wantBuildType: "spring",
+		},
+		"success case: node.js project": {
+			in:            path.Join("..", "resources", "test", "node-project"),
+			wantLanguage:  "node",
+			wantBuildType: "node",
+		},
+		"success case: swift project": {
+			in:            path.Join("..", "resources", "test", "swift-project"),
+			wantLanguage:  "swift",
+			wantBuildType: "swift",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotLanguage, gotBuildType := DetermineProjectInfo(test.in)
+
+			assert.Equal(t, test.wantLanguage, gotLanguage)
+			assert.Equal(t, test.wantBuildType, gotBuildType)
+		})
+	}
+}
+
+func TestWriteNewCwSettings(t *testing.T) {
+	defaultInternalDebugPort := ""
+	tests := map[string]struct {
+		inProjectPath  string
+		inBuildType    string
+		wantCwSettings CWSettings
+	}{
+		"success case: node project": {
+			inProjectPath: "../resources/test/node-project/.cw-settings",
+			inBuildType:   "nodejs",
+			wantCwSettings: CWSettings{
+				ContextRoot:       "",
+				InternalPort:      "",
+				HealthCheck:       "",
+				IgnoredPaths:      []string{""},
+				InternalDebugPort: &defaultInternalDebugPort,
+			},
+		},
+		"success case: liberty project": {
+			inProjectPath: "../resources/test/liberty-project/.cw-settings",
+			inBuildType:   "liberty",
+			wantCwSettings: CWSettings{
+				ContextRoot:       "",
+				InternalPort:      "",
+				HealthCheck:       "",
+				IgnoredPaths:      []string{""},
+				InternalDebugPort: &defaultInternalDebugPort,
+				MavenProfiles:     []string{""},
+				MavenProperties:   []string{""},
+			},
+		},
+		"success case: spring project": {
+			inProjectPath: "../resources/test/spring-project/.cw-settings",
+			inBuildType:   "spring",
+			wantCwSettings: CWSettings{
+				ContextRoot:       "",
+				InternalPort:      "",
+				HealthCheck:       "",
+				IgnoredPaths:      []string{""},
+				InternalDebugPort: &defaultInternalDebugPort,
+				MavenProfiles:     []string{""},
+				MavenProperties:   []string{""},
+			},
+	},
+		"success case: swift project": {
+			inProjectPath: "../resources/test/swift-project/.cw-settings",
+			inBuildType:   "swift",
+			wantCwSettings: CWSettings{
+				ContextRoot:  "",
+				InternalPort: "",
+				HealthCheck:  "",
+				IgnoredPaths: []string{""},
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			WriteNewCwSettings(test.inProjectPath, test.inBuildType)
+
+			cwSettings := readCwSettings(test.inProjectPath)
+			assert.Equal(t, test.wantCwSettings, cwSettings)
+
+			os.Remove(test.inProjectPath)
+		})
+	}
+}
+
+func readCwSettings(filepath string) CWSettings {
+	cwSettingsFile, err := ioutil.ReadFile(filepath)
+	if err != nil {
+		log.Println(err)
+		return CWSettings{}
+	}
+	var cwSettings CWSettings
+	json.Unmarshal(cwSettingsFile, &cwSettings)
+	return cwSettings
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -11,6 +11,11 @@
 
 package utils
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 // RemoveDuplicateEntries elements
 func RemoveDuplicateEntries(inputArr []string) []string {
 
@@ -30,4 +35,9 @@ func RemoveDuplicateEntries(inputArr []string) []string {
 	}
 
 	return result
+}
+
+func PrettyPrintJSON(i interface{}) {
+	s, _ := json.MarshalIndent(i, "", "\t")
+	fmt.Println(string(s))
 }


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

## Problem
To manage project templates, Codewind Vscode plugins want to call this Go CLI rather than Codewind's REST API directly. Currently the CLI can list all templates, but cannot filter those templates.

## Solution
Add 2 optional flags to filter templates:
1. `codewind-installer templates -projectStyle="Codewind"` calls Codewind's REST API `GET templates?projectStyle=Codewind` to list all templates with projectStyle "Codewind"

2. `codewind-installer templates -showEnabledOnly="true"` calls Codewind's REST API `GET templates?showEnabledOnly=true` to list all templates from enabled template repositories.

They can be used in conjunction.

## Tests
- Unit tests (automated)
- Integration tests (manual. Automated tests coming soon).